### PR TITLE
Add browser-based HomeLLM escalation workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# Kertokt
-Stuff.
+# HomeLLM
+
+HomeLLM is a lightweight, browser-based workspace that helps indoor environmental consultants draft data-driven escalation emails to HOAs, utilities, local governments, state agencies, and nonprofits. The tool combines structured guidance, curated statutes, and a transparent training dataset to make advocacy correspondence fast and repeatable.
+
+## Features
+
+- **Guided Email Composer** – capture investigation details, upload evidence, and instantly produce a structured escalation email ready for review.
+- **Evidence & Regulation Prompts** – contextual reminders of sampling data, statutory obligations, and urgency guidance for each recipient type.
+- **Training Dataset Viewer** – inspect prompt/response pairs that can be used to prime or fine-tune language models powering HomeLLM workflows.
+- **Attachment Tracking** – log supporting files (photos, lab reports) to include in outreach packages.
+- **Offline-Friendly** – ships as static HTML, CSS, and JavaScript. No build step or external dependencies required.
+
+## Getting Started
+
+1. Serve the project locally (any static file server works). One option using Python:
+
+   ```bash
+   npm run start
+   ```
+
+   The command above launches `python3 -m http.server` on port `5173`. Navigate to [http://localhost:5173](http://localhost:5173) in your browser.
+
+2. Populate the form with investigation details. Optional: paste an API key from your preferred LLM provider to track where you plan to run generations (keys are stored only in-browser).
+3. Click **Generate Email** to create a subject line and body. Copy or download the text for final review and sending.
+4. Switch to the **Training Dataset** tab to review curated prompt/completion examples. These entries illustrate how to cite regulations accurately when automating escalations.
+
+## Project Structure
+
+```
+index.html          # Entry point and layout container
+src/styles.css      # Styling for the application
+src/main.js         # UI logic, event handling, state management
+src/data/           # Domain guidance, regulations, and training dataset
+src/utils/          # Email assembly utilities
+```
+
+## Customizing Guidance
+
+- Update `src/data/escalationRules.js` to add new jurisdictions, issue types, or recipient obligations.
+- Expand `src/data/trainingDataset.js` with additional prompt/completion pairs as new cases are handled.
+- Adapt `src/utils/emailTemplates.js` if you need to tweak the generated email format or include new data fields.
+
+## Notes on Accuracy
+
+All regulations and references included in the dataset cite recognized federal and state sources. Always confirm jurisdiction-specific requirements before sending correspondence, and have licensed professionals review legal notices when necessary.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HomeLLM – Email Escalation Assistant</title>
+    <link rel="stylesheet" href="src/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "homellm",
+  "version": "1.0.0",
+  "description": "HomeLLM - email escalation helper and training dataset viewer.",
+  "license": "MIT",
+  "scripts": {
+    "start": "python3 -m http.server 5173"
+  }
+}

--- a/src/data/escalationRules.js
+++ b/src/data/escalationRules.js
@@ -1,0 +1,287 @@
+export const issueGuidance = {
+  'air-quality': {
+    label: 'Air Quality / Mold / VOCs',
+    summary:
+      'Document moisture sources, sampling data, and ventilation performance. Reference ASHRAE 62.1/62.2 ventilation targets and OSHA mold guidance when worker exposure is relevant.',
+    evidencePoints: [
+      'Humidity readings above 60% RH or sustained dampness support mold concerns.',
+      'Photographs of visible mold growth, water intrusion, or damaged drywall strengthen the narrative.',
+      'Include laboratory findings for spore counts, VOC levels, or particulate analysis if available.'
+    ],
+    regulations: [
+      {
+        title: 'EPA Mold Remediation in Schools and Commercial Buildings',
+        url: 'https://www.epa.gov/mold/mold-remediation-schools-and-commercial-buildings-guide'
+      },
+      {
+        title: 'ASHRAE Standard 62.2 – Ventilation and Acceptable Indoor Air Quality',
+        url: 'https://www.ashrae.org/technical-resources/standards-and-guidelines'
+      }
+    ]
+  },
+  'water-quality': {
+    label: 'Water Quality / Contamination',
+    summary:
+      'Report contaminant concentrations, sampling dates, and EPA Maximum Contaminant Level (MCL) comparisons. Note any boil water notices or municipal advisories.',
+    evidencePoints: [
+      'Include water sampling laboratory results and chain of custody if available.',
+      'Photographs of discolored water, residue, or plumbing corrosion help illustrate severity.',
+      'Document odors, taste issues, or health symptoms experienced by residents.'
+    ],
+    regulations: [
+      {
+        title: 'Safe Drinking Water Act (40 CFR Parts 141-149)',
+        url: 'https://www.epa.gov/sdwa'
+      },
+      {
+        title: 'EPA Lead and Copper Rule (40 CFR Part 141 Subpart I)',
+        url: 'https://www.epa.gov/dwreginfo/lead-and-copper-rule'
+      }
+    ]
+  },
+  'hvac-ventilation': {
+    label: 'HVAC / Ventilation Issues',
+    summary:
+      'Describe ventilation rates, filter performance, and maintenance history. Compare airflow measurements to ASHRAE or local building code requirements.',
+    evidencePoints: [
+      'Include test and balance reports or airflow readings from supply and return vents.',
+      'Provide filter replacement logs and photos of clogged filters or blocked vents.',
+      'Summarize comfort complaints, carbon dioxide trends, or occupancy impacts.'
+    ],
+    regulations: [
+      {
+        title: 'International Mechanical Code §403 (Ventilation)',
+        url: 'https://codes.iccsafe.org'
+      }
+    ]
+  },
+  'lead-asbestos': {
+    label: 'Lead / Asbestos / Hazardous Materials',
+    summary:
+      'Highlight accredited inspection results, abatement requirements, and occupant protection plans. Reference HUD/EPA disclosure rules for pre-1978 housing.',
+    evidencePoints: [
+      'Attach certified laboratory reports showing lead paint or asbestos concentrations.',
+      'Document containment failures, friable material, or dust wipe exceedances.',
+      'Describe vulnerable populations (children under six, pregnant residents) impacted.'
+    ],
+    regulations: [
+      {
+        title: 'EPA Renovation, Repair, and Painting Rule (40 CFR Part 745 Subpart E)',
+        url: 'https://www.epa.gov/lead'
+      },
+      {
+        title: 'AHERA Asbestos Requirements (40 CFR Part 763)',
+        url: 'https://www.epa.gov/asbestos/asbestos-laws-and-regulations'
+      }
+    ]
+  },
+  'utility-access': {
+    label: 'Utility Access / Service Issues',
+    summary:
+      'Document service interruptions, billing disputes, or unsafe utility infrastructure. Reference state public utility commission rules for response times and reliability.',
+    evidencePoints: [
+      'Capture outage logs, communication records, and meter readings.',
+      'Show invoices or notices reflecting disputed charges or shutoff threats.',
+      'Document any medical baseline customers requiring uninterrupted service.'
+    ],
+    regulations: [
+      {
+        title: 'Public Utility Commission customer service standards (state-specific)',
+        url: 'https://www.naruc.org/about-naruc/regulatory-commissions'
+      }
+    ]
+  }
+};
+
+export const recipientGuidance = {
+  hoa: {
+    label: 'Homeowners Association (HOA)',
+    tone: 'professional and cooperative',
+    obligations: [
+      'HOAs must enforce CC&Rs consistently and maintain common areas affecting health and safety.',
+      'Many states adopt the Uniform Common Interest Ownership Act (UCIOA) which requires prompt action on hazards.',
+      'Fair Housing Act protections apply when indoor environmental issues disproportionately impact protected classes.'
+    ],
+    requestedActions: [
+      'Schedule inspection of common infrastructure affecting the unit(s).',
+      'Provide written remediation plan with timelines and responsible vendors.',
+      'Reimburse residents for out-of-pocket mitigation costs when delays are attributable to the HOA.'
+    ]
+  },
+  'property-mgmt': {
+    label: 'Property Management / Landlord',
+    tone: 'firm and reference habitability statutes',
+    obligations: [
+      'Landlords must maintain habitable premises under the implied warranty of habitability.',
+      'Many jurisdictions require response to essential service complaints within 24–72 hours.',
+      'Retaliation for reporting health hazards is prohibited under most landlord-tenant acts.'
+    ],
+    requestedActions: [
+      'Acknowledge the complaint in writing and provide inspection schedule.',
+      'Engage licensed contractors for assessment and remediation.',
+      'Offer temporary relocation support if the dwelling is unsafe during repairs.'
+    ]
+  },
+  utility: {
+    label: 'Utility Company',
+    tone: 'escalatory yet collaborative',
+    obligations: [
+      'Utilities are regulated by state Public Utility Commissions (PUCs) and must follow outage communication protocols.',
+      'Critical care and medical baseline customers are entitled to prioritized restoration.',
+      'Billing disputes must be investigated before disconnection when raised in good faith.'
+    ],
+    requestedActions: [
+      'Provide written confirmation of the investigation timeline and responsible department.',
+      'Issue credit adjustments or service restoration where warranted.',
+      'Share contingency plans for vulnerable residents during extended outages.'
+    ]
+  },
+  'local-govt': {
+    label: 'Local Government / City Council',
+    tone: 'civic and data-driven',
+    obligations: [
+      'Municipal code enforcement divisions can cite properties that violate property maintenance codes.',
+      'Local health departments may issue orders to abate indoor environmental hazards.',
+      'City councils track systemic issues and can escalate to special hearings or funding programs.'
+    ],
+    requestedActions: [
+      'Initiate inspection under applicable municipal code sections.',
+      'Coordinate with public health officials to evaluate community-level risk.',
+      'Consider allocating resources or grants to resolve infrastructure deficiencies.'
+    ]
+  },
+  'state-agency': {
+    label: 'State Environmental/Health Agency',
+    tone: 'formal and evidence-heavy',
+    obligations: [
+      'State environmental quality and health departments enforce state statutes and EPA-delegated programs.',
+      'Agencies maintain complaint hotlines for drinking water, mold, radon, and lead.',
+      'They can compel responsible parties to submit corrective action plans and progress reports.'
+    ],
+    requestedActions: [
+      'Open a case number and assign investigator contact information.',
+      'Review submitted data and schedule on-site sampling if needed.',
+      'Issue enforcement orders or guidance to the HOA/utility/owner as appropriate.'
+    ]
+  },
+  'federal-agency': {
+    label: 'Federal Agency (EPA, HUD, etc.)',
+    tone: 'formal and compliant with federal reporting procedures',
+    obligations: [
+      'Federal agencies oversee national programs such as the Safe Drinking Water Act, HUD Healthy Homes, and OSHA worker safety standards.',
+      'They rely on detailed documentation to prioritize enforcement actions.',
+      'Whistleblower protections may apply when reporting violations of federal law.'
+    ],
+    requestedActions: [
+      'Confirm receipt and advise on required federal forms or supplemental data.',
+      'Coordinate with delegated state agencies to ensure rapid response.',
+      'Provide technical assistance resources and enforcement timeline expectations.'
+    ]
+  },
+  nonprofit: {
+    label: 'Advocacy Nonprofit / Legal Aid',
+    tone: 'collaborative and impact-focused',
+    obligations: [
+      'Nonprofits can offer strategic guidance, legal support, and media engagement.',
+      'Documented cases help organizations demonstrate trends and secure funding.',
+      'They typically require consent to share resident stories or data.'
+    ],
+    requestedActions: [
+      'Review attached evidence and advise on strategic next steps.',
+      'Support outreach to regulators, media, or pro bono counsel.',
+      'Provide template filings or scripts for additional resident testimonies.'
+    ]
+  }
+};
+
+export const escalationStyles = {
+  initial: {
+    label: 'Initial Request',
+    guidance:
+      'Open with appreciation, describe the issue succinctly, and request confirmation of receipt. Offer collaboration and avoid accusatory language.'
+  },
+  professional: {
+    label: 'Professional Follow-up',
+    guidance:
+      'Reference prior communications, cite relevant obligations, and request a written action plan with deadlines.'
+  },
+  formal: {
+    label: 'Formal Complaint',
+    guidance:
+      'Cite statutes, attach evidence, and clearly state expectations for remediation timelines. Note that the correspondence will be retained for potential enforcement.'
+  },
+  legal: {
+    label: 'Legal Notice',
+    guidance:
+      'State that failure to act may result in legal remedies, reference counsel if retained, and provide a firm deadline for compliance.'
+  }
+};
+
+export const urgencyGuidance = {
+  low: 'Issue affects quality of life but does not present an immediate health risk. Request action within 14 days.',
+  medium: 'Residents experience health or comfort impacts. Request action within 7 days and ask for interim mitigation steps.',
+  high: 'Significant health impacts or ongoing code violations. Request action within 48 hours and emphasize duty of care.',
+  emergency: 'Immediate threat to life or property. Demand urgent response (24 hours or less) and consider temporary relocation or emergency services.'
+};
+
+export const stateRegulations = {
+  California: [
+    {
+      citation: 'California Health & Safety Code §17920.3',
+      summary: 'Defines substandard building conditions including dampness, mold, and inadequate sanitation.'
+    },
+    {
+      citation: 'California Civil Code §1941.1',
+      summary: 'Lists landlord obligations to maintain habitable dwellings, including plumbing, heating, and weatherproofing.'
+    },
+    {
+      citation: 'California Public Utilities Code §777-779',
+      summary: 'Requires utilities to provide notice and protections before service disconnection.'
+    }
+  ],
+  'New York': [
+    {
+      citation: 'NYC Administrative Code §27-2017.3',
+      summary: 'Classifies indoor mold hazards and timelines for remediation depending on apartment size.'
+    },
+    {
+      citation: 'New York Public Health Law §1110',
+      summary: 'Authorizes the health department to address public health nuisances including contaminated water.'
+    }
+  ],
+  Texas: [
+    {
+      citation: 'Texas Property Code §92.052',
+      summary: 'Requires landlords to repair conditions that materially affect the health or safety of tenants.'
+    },
+    {
+      citation: 'Texas Administrative Code Title 25 Part 1 Chapter 295',
+      summary: 'Details mold assessment and remediation licensing and notification requirements.'
+    }
+  ],
+  Florida: [
+    {
+      citation: 'Florida Statutes §83.51',
+      summary: 'Obligates landlords to maintain property in compliance with applicable building, housing, and health codes.'
+    },
+    {
+      citation: 'Florida Administrative Code Rule 62-550',
+      summary: 'Implements federal drinking water regulations and reporting requirements.'
+    }
+  ]
+};
+
+export const federalReferences = [
+  {
+    citation: 'Fair Housing Act (42 U.S.C. §3601 et seq.)',
+    summary: 'Prohibits discriminatory housing practices, including failure to address hazards impacting protected classes.'
+  },
+  {
+    citation: 'Americans with Disabilities Act Title II',
+    summary: 'Public entities must ensure programs and services are accessible, including reasonable accommodations for environmental sensitivities.'
+  },
+  {
+    citation: 'Safe Drinking Water Act',
+    summary: 'Establishes national standards for public drinking water systems and enforcement mechanisms.'
+  }
+];

--- a/src/data/trainingDataset.js
+++ b/src/data/trainingDataset.js
@@ -1,0 +1,23 @@
+export const trainingDataset = [
+  {
+    id: 'hoa-mold-followup',
+    prompt:
+      'Draft a professional follow-up email to an HOA about mold in shared HVAC ducts. Include humidity readings, prior requests, and cite UCIOA obligations.',
+    completion:
+      'Subject: Follow-up: Mold Remediation Required for Building HVAC Ducts\n\nDear Board Members,\n\nThank you for acknowledging our initial request regarding the visible mold inside the shared HVAC ducts serving Building C. On 3 May we measured relative humidity above 68% inside the trunks and confirmed condensation along the insulation. As referenced in the UCIOA §3-107, the association must maintain common elements in a condition that protects resident health.\n\nWe respectfully ask the Board to confirm the remediation contractor selection and schedule no later than 10 May. Please provide the written work plan, including containment procedures and post-remediation verification.\n\nKind regards,\nHomeLLM Resident Advocacy Team'
+  },
+  {
+    id: 'utility-water-billing',
+    prompt:
+      'Create an escalation email to a water utility disputing bills after documented service interruptions. Reference state PUC complaint procedures and request credits.',
+    completion:
+      'Subject: Escalation: Billing Adjustment Request for Service Interruptions\n\nTo the Customer Relations Manager,\n\nBetween 12–15 April our monitoring equipment recorded four pressure drops below 20 psi at 145 Cedar Street, leading to boil water advisories for residents. The outages were reported via ticket #44821, yet the April invoice still reflects full volumetric and service charges. Under Texas Administrative Code 16 TAC §24.173, utilities must investigate disputed bills before disconnecting service or assessing late fees.\n\nPlease apply an outage credit, waive penalties, and share the mitigation steps to prevent recurrence. If we do not receive written confirmation within five business days, we will file a formal complaint with the Public Utility Commission of Texas.\n\nSincerely,\nHomeLLM Resident Advocacy Team'
+  },
+  {
+    id: 'state-lead-hazard',
+    prompt:
+      'Write a formal complaint to a state health agency about lead dust hazards in pre-1978 apartments, referencing EPA RRP rules and requesting inspection.',
+    completion:
+      'Subject: Formal Complaint: Lead Dust Hazards at 218 Harbor Avenue\n\nTo the Lead Hazard Control Program,\n\nHomeLLM conducted XRF screening and dust wipe sampling at 218 Harbor Avenue on 22 March. Two bedroom sills exceeded the EPA dust-lead hazard standard (140 µg/ft²) and deteriorated lead-based paint was observed on common stair rails. These conditions fall under the EPA Renovation, Repair, and Painting Rule (40 CFR Part 745 Subpart E) and require certified abatement.\n\nWe request that the Department open an investigation, inspect the property, and direct the owner to submit a compliant abatement plan within 10 days. Please confirm the assigned investigator and next steps.\n\nRespectfully,\nHomeLLM Resident Advocacy Team'
+  }
+];

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,513 @@
+import {
+  issueGuidance,
+  recipientGuidance,
+  escalationStyles,
+  urgencyGuidance,
+  stateRegulations
+} from './data/escalationRules.js';
+import { trainingDataset } from './data/trainingDataset.js';
+import { buildEmail } from './utils/emailTemplates.js';
+
+const defaultFormState = {
+  issueType: 'air-quality',
+  recipient: 'hoa',
+  location: '',
+  city: '',
+  state: '',
+  evidence: '',
+  measurements: '',
+  previousContact: '',
+  healthImpact: '',
+  regulations: '',
+  desiredOutcome: '',
+  escalationLevel: 'professional',
+  affectedResidents: '',
+  propertyAge: '',
+  urgencyLevel: 'medium',
+  senderName: '',
+  senderEmail: '',
+  senderPhone: '',
+  senderAddress: '',
+  apiKey: ''
+};
+
+class HomeLLMApp {
+  constructor(root) {
+    this.root = root;
+    this.state = { ...defaultFormState };
+    this.attachments = [];
+    this.activeTab = 'composer';
+    this.generatedEmail = '';
+    this.render();
+  }
+
+  render() {
+    this.root.innerHTML = `
+      <header class="header">
+        <div>
+          <h1>HomeLLM</h1>
+          <p>Indoor environmental advocacy assistant for rapid, accurate escalations.</p>
+        </div>
+        <span class="badge">Indoor Health Ops</span>
+      </header>
+
+      <section class="panel">
+        <div class="tab-bar">
+          <button class="tab-button ${this.activeTab === 'composer' ? 'active' : ''}" data-tab="composer">Email Composer</button>
+          <button class="tab-button ${this.activeTab === 'dataset' ? 'active' : ''}" data-tab="dataset">Training Dataset</button>
+        </div>
+
+        <div id="tab-composer" class="tab-content ${this.activeTab === 'composer' ? '' : 'hidden'}">
+          ${this.renderComposer()}
+        </div>
+
+        <div id="tab-dataset" class="tab-content ${this.activeTab === 'dataset' ? '' : 'hidden'}">
+          ${this.renderDataset()}
+        </div>
+      </section>
+    `;
+
+    this.bindTabEvents();
+    this.bindComposerEvents();
+    this.bindDatasetEvents();
+  }
+
+  renderComposer() {
+    const stateOptions = [''].concat(Object.keys(stateRegulations)).sort();
+    return `
+      <div class="panel" style="padding: 0; box-shadow: none;">
+        <div class="panel" style="margin-bottom: 16px;">
+          <h2 class="section-title">API Configuration</h2>
+          <div class="grid-two">
+            <div class="field">
+              <label for="apiKey">Model API Key</label>
+              <input type="password" id="apiKey" name="apiKey" placeholder="Paste provider key (optional)" value="${this.escape(
+                this.state.apiKey
+              )}" />
+              <small>Keys are stored locally in your browser session only.</small>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-bottom: 16px;">
+          <h2 class="section-title">Case Overview</h2>
+          <div class="grid-two">
+            <div class="field">
+              <label for="issueType">Issue Type</label>
+              <select id="issueType" name="issueType">
+                ${Object.entries(issueGuidance)
+                  .map(([value, data]) => `<option value="${value}" ${
+                    this.state.issueType === value ? 'selected' : ''
+                  }>${data.label}</option>`)
+                  .join('')}
+              </select>
+            </div>
+            <div class="field">
+              <label for="recipient">Recipient</label>
+              <select id="recipient" name="recipient">
+                ${Object.entries(recipientGuidance)
+                  .map(([value, data]) => `<option value="${value}" ${
+                    this.state.recipient === value ? 'selected' : ''
+                  }>${data.label}</option>`)
+                  .join('')}
+              </select>
+            </div>
+            <div class="field">
+              <label for="escalationLevel">Escalation Level</label>
+              <select id="escalationLevel" name="escalationLevel">
+                ${Object.entries(escalationStyles)
+                  .map(([value, data]) => `<option value="${value}" ${
+                    this.state.escalationLevel === value ? 'selected' : ''
+                  }>${data.label}</option>`)
+                  .join('')}
+              </select>
+            </div>
+            <div class="field">
+              <label for="urgencyLevel">Urgency</label>
+              <select id="urgencyLevel" name="urgencyLevel">
+                ${Object.entries(urgencyGuidance)
+                  .map(([value]) => `<option value="${value}" ${
+                    this.state.urgencyLevel === value ? 'selected' : ''
+                  }>${value.charAt(0).toUpperCase() + value.slice(1)}</option>`)
+                  .join('')}
+              </select>
+            </div>
+          </div>
+
+          <div class="grid-two" style="margin-top: 16px;">
+            <div class="field">
+              <label for="location">Property / System</label>
+              <input id="location" name="location" placeholder="e.g., Building C – Shared HVAC" value="${this.escape(
+                this.state.location
+              )}" />
+            </div>
+            <div class="field">
+              <label for="city">City</label>
+              <input id="city" name="city" placeholder="City" value="${this.escape(this.state.city)}" />
+            </div>
+            <div class="field">
+              <label for="state">State</label>
+              <select id="state" name="state">
+                ${stateOptions
+                  .map((value) => {
+                    const label = value ? value : 'Select state';
+                    return `<option value="${value}" ${this.state.state === value ? 'selected' : ''}>${label}</option>`;
+                  })
+                  .join('')}
+              </select>
+            </div>
+            <div class="field">
+              <label for="propertyAge">Property / Equipment Age</label>
+              <input id="propertyAge" name="propertyAge" placeholder="e.g., Constructed 1995, last HVAC retrofit 2018" value="${this.escape(
+                this.state.propertyAge
+              )}" />
+            </div>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-bottom: 16px;">
+          <h2 class="section-title">Findings & Impacts</h2>
+          <div class="grid-two">
+            <div class="field">
+              <label for="measurements">Measurements</label>
+              <textarea id="measurements" name="measurements" placeholder="Include sampling results, humidity, airflow, ppm data">${this.escape(
+                this.state.measurements
+              )}</textarea>
+            </div>
+            <div class="field">
+              <label for="evidence">Observations / Evidence</label>
+              <textarea id="evidence" name="evidence" placeholder="Visible issues, photos, logs, corrective actions to date">${this.escape(
+                this.state.evidence
+              )}</textarea>
+            </div>
+          </div>
+          <div class="grid-two" style="margin-top: 16px;">
+            <div class="field">
+              <label for="healthImpact">Health Impacts</label>
+              <textarea id="healthImpact" name="healthImpact" placeholder="Symptoms reported, doctor notes, vulnerable residents">${this.escape(
+                this.state.healthImpact
+              )}</textarea>
+            </div>
+            <div class="field">
+              <label for="affectedResidents">Affected Residents / Units</label>
+              <textarea id="affectedResidents" name="affectedResidents" placeholder="List units, residents, or population counts">${this.escape(
+                this.state.affectedResidents
+              )}</textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-bottom: 16px;">
+          <h2 class="section-title">Regulatory & Communication History</h2>
+          <div class="grid-two">
+            <div class="field">
+              <label for="regulations">Local Regulations Referenced</label>
+              <textarea id="regulations" name="regulations" placeholder="Cite municipal codes or standards residents have identified">${this.escape(
+                this.state.regulations
+              )}</textarea>
+            </div>
+            <div class="field">
+              <label for="previousContact">Previous Contact History</label>
+              <textarea id="previousContact" name="previousContact" placeholder="Dates, ticket numbers, phone calls, inspection requests">${this.escape(
+                this.state.previousContact
+              )}</textarea>
+            </div>
+          </div>
+          <div class="field" style="margin-top: 16px;">
+            <label for="desiredOutcome">Desired Outcome</label>
+            <textarea id="desiredOutcome" name="desiredOutcome" placeholder="Describe remediation goals, credits, or relief requested">${this.escape(
+              this.state.desiredOutcome
+            )}</textarea>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-bottom: 16px;">
+          <h2 class="section-title">Documentation Uploads</h2>
+          <div class="field">
+            <label for="attachmentInput">Attach Evidence (images, PDFs)</label>
+            <input id="attachmentInput" type="file" multiple accept="image/*,.pdf,.doc,.docx" />
+            <div class="attachments" id="attachmentsList">${
+              this.attachments.length
+                ? this.attachments
+                    .map(
+                      (file, index) => `
+                      <div class="attachment-item" data-index="${index}">
+                        <span>${file.name}</span>
+                        <button type="button" data-remove="${index}">Remove</button>
+                      </div>`
+                    )
+                    .join('')
+                : '<span>No files attached yet.</span>'
+            }</div>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-bottom: 16px;">
+          <h2 class="section-title">Sender Details</h2>
+          <div class="grid-two">
+            <div class="field">
+              <label for="senderName">Sender Name</label>
+              <input id="senderName" name="senderName" placeholder="HomeLLM Advocate" value="${this.escape(
+                this.state.senderName
+              )}" />
+            </div>
+            <div class="field">
+              <label for="senderEmail">Email</label>
+              <input id="senderEmail" name="senderEmail" placeholder="advocate@example.com" value="${this.escape(
+                this.state.senderEmail
+              )}" />
+            </div>
+            <div class="field">
+              <label for="senderPhone">Phone</label>
+              <input id="senderPhone" name="senderPhone" placeholder="(555) 123-4567" value="${this.escape(
+                this.state.senderPhone
+              )}" />
+            </div>
+            <div class="field">
+              <label for="senderAddress">Mailing Address</label>
+              <input id="senderAddress" name="senderAddress" placeholder="123 Air Quality Ln, Suite 200" value="${this.escape(
+                this.state.senderAddress
+              )}" />
+            </div>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-bottom: 16px;">
+          <h2 class="section-title">Guidance Snapshot</h2>
+          <div id="guidanceContainer">${this.renderGuidance()}</div>
+        </div>
+
+        <div class="panel">
+          <div class="button-row">
+            <button id="generateEmail" class="btn btn-primary">Generate Email</button>
+            <button id="copyEmail" class="btn btn-secondary" ${
+              this.generatedEmail ? '' : 'disabled'
+            }>Copy Email</button>
+            <button id="downloadEmail" class="btn btn-tertiary" ${
+              this.generatedEmail ? '' : 'disabled'
+            }>Download .txt</button>
+            <button id="resetForm" class="btn btn-tertiary">Reset</button>
+          </div>
+
+          <div class="generated-email">
+            <label for="generatedEmail">Generated Email</label>
+            <textarea id="generatedEmail" readonly placeholder="Generated email will appear here">${this.escape(
+              this.generatedEmail
+            )}</textarea>
+          </div>
+          <div id="statusArea"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  renderDataset() {
+    return `
+      <div>
+        <h2 class="section-title">Curated Training Examples</h2>
+        <p>The following dataset entries are structured prompt-completion pairs for fine-tuning or evaluation.</p>
+        <table class="training-table">
+          <thead>
+            <tr>
+              <th style="width: 18%">ID</th>
+              <th style="width: 30%">Prompt</th>
+              <th>Completion</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${trainingDataset
+              .map(
+                (item) => `
+                  <tr>
+                    <td><strong>${item.id}</strong></td>
+                    <td><code>${this.escape(item.prompt)}</code></td>
+                    <td><code>${this.escape(item.completion)}</code></td>
+                  </tr>`
+              )
+              .join('')}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  renderGuidance() {
+    const issueData = issueGuidance[this.state.issueType];
+    const recipientData = recipientGuidance[this.state.recipient];
+    const escalation = escalationStyles[this.state.escalationLevel];
+    const urgency = urgencyGuidance[this.state.urgencyLevel];
+
+    const stateRefs = this.state.state && stateRegulations[this.state.state] ? stateRegulations[this.state.state] : [];
+
+    if (!issueData || !recipientData || !escalation) {
+      return '<p>Update the case selections above to view tailored guidance.</p>';
+    }
+
+    return `
+      <div class="guidance-card">
+        <h4>Issue Focus – ${issueData.label}</h4>
+        <p>${issueData.summary}</p>
+        <ul>
+          ${issueData.evidencePoints.map((point) => `<li>${point}</li>`).join('')}
+        </ul>
+      </div>
+      <div class="guidance-card">
+        <h4>Recipient Expectations – ${recipientData.label}</h4>
+        <p>Tone: <strong>${recipientData.tone}</strong></p>
+        <ul>
+          ${recipientData.obligations.map((item) => `<li>${item}</li>`).join('')}
+        </ul>
+      </div>
+      <div class="guidance-card">
+        <h4>Escalation Strategy</h4>
+        <p>${escalation.guidance}</p>
+        <p><strong>Urgency guidance:</strong> ${urgency}</p>
+      </div>
+      <div class="guidance-card">
+        <h4>State References ${this.state.state ? `– ${this.state.state}` : ''}</h4>
+        ${stateRefs.length
+          ? `<ul>${stateRefs.map((ref) => `<li><strong>${ref.citation}</strong>: ${ref.summary}</li>`).join('')}</ul>`
+          : '<p>Select a state to surface state-level statutes and regulations.</p>'}
+      </div>
+    `;
+  }
+
+  bindTabEvents() {
+    this.root.querySelectorAll('.tab-button').forEach((button) => {
+      button.addEventListener('click', () => {
+        const tab = button.dataset.tab;
+        if (tab !== this.activeTab) {
+          this.activeTab = tab;
+          this.render();
+        }
+      });
+    });
+  }
+
+  bindComposerEvents() {
+    const composer = this.root.querySelector('#tab-composer');
+    if (!composer) return;
+
+    composer.querySelectorAll('input, textarea, select').forEach((element) => {
+      element.addEventListener('input', (event) => {
+        const { name, value } = event.target;
+        if (name in this.state) {
+          this.state[name] = value;
+        }
+        if (['issueType', 'recipient', 'escalationLevel', 'urgencyLevel', 'state'].includes(name)) {
+          this.updateGuidance();
+        }
+      });
+    });
+
+    const attachmentInput = composer.querySelector('#attachmentInput');
+    attachmentInput.addEventListener('change', (event) => this.handleAttachmentUpload(event));
+
+    composer.querySelector('#generateEmail').addEventListener('click', () => this.handleGenerate());
+    composer.querySelector('#copyEmail').addEventListener('click', () => this.copyEmail());
+    composer.querySelector('#downloadEmail').addEventListener('click', () => this.downloadEmail());
+    composer.querySelector('#resetForm').addEventListener('click', () => this.resetForm());
+
+    composer.querySelectorAll('[data-remove]').forEach((button) => {
+      button.addEventListener('click', (event) => {
+        const index = Number(event.target.dataset.remove);
+        this.attachments.splice(index, 1);
+        this.render();
+      });
+    });
+  }
+
+  bindDatasetEvents() {
+    // For extensibility; currently static view.
+  }
+
+  handleAttachmentUpload(event) {
+    const files = Array.from(event.target.files);
+    const readers = files.map((file) => {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          resolve({ name: file.name, type: file.type, data: reader.result });
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(file);
+      });
+    });
+
+    Promise.all(readers)
+      .then((results) => {
+        this.attachments = this.attachments.concat(results);
+        this.render();
+        this.showStatus(`${results.length} attachment(s) added.`, 'success');
+      })
+      .catch((error) => {
+        this.showStatus(`Attachment error: ${error.message}`, 'error');
+      });
+  }
+
+  handleGenerate() {
+    const { subject, body } = buildEmail(this.state, this.attachments);
+    this.generatedEmail = `Subject: ${subject}\n\n${body}`;
+    this.render();
+    this.showStatus('Email generated successfully. Review and customize before sending.', 'success');
+  }
+
+  copyEmail() {
+    if (!this.generatedEmail) return;
+    navigator.clipboard
+      .writeText(this.generatedEmail)
+      .then(() => this.showStatus('Email copied to clipboard.', 'success'))
+      .catch(() => this.showStatus('Unable to access clipboard in this browser.', 'error'));
+  }
+
+  downloadEmail() {
+    if (!this.generatedEmail) return;
+    const blob = new Blob([this.generatedEmail], { type: 'text/plain' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'HomeLLM-escalation-email.txt';
+    link.click();
+    URL.revokeObjectURL(link.href);
+    this.showStatus('Text file downloaded.', 'success');
+  }
+
+  resetForm() {
+    this.state = { ...defaultFormState };
+    this.attachments = [];
+    this.generatedEmail = '';
+    this.render();
+    this.showStatus('Form reset. All fields cleared.', 'success');
+  }
+
+  updateGuidance() {
+    const container = this.root.querySelector('#guidanceContainer');
+    if (container) {
+      container.innerHTML = this.renderGuidance();
+    }
+  }
+
+  showStatus(message, type) {
+    const statusArea = this.root.querySelector('#statusArea');
+    if (!statusArea) return;
+    statusArea.innerHTML = `<div class="status ${type === 'error' ? 'error' : ''}">${message}</div>`;
+    setTimeout(() => {
+      if (statusArea) statusArea.innerHTML = '';
+    }, 4000);
+  }
+
+  escape(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.getElementById('app');
+  if (root) {
+    new HomeLLMApp(root);
+  }
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,292 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 100%);
+  min-height: 100vh;
+}
+
+#app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.header h1 {
+  font-size: 2rem;
+  margin: 0;
+  color: #0f172a;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.1);
+  color: #2563eb;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.panel {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.35);
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.tab-bar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.tab-button {
+  border: none;
+  background: rgba(148, 163, 184, 0.2);
+  color: #1e293b;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab-button.active {
+  background: #1d4ed8;
+  color: white;
+  box-shadow: 0 6px 18px rgba(37, 99, 235, 0.35);
+}
+
+.grid-two {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.field input,
+.field select,
+.field textarea {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  font: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(248, 250, 252, 0.8);
+}
+
+.field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  background: white;
+}
+
+.section-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 24px 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.btn {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary {
+  background: #1d4ed8;
+  color: white;
+  box-shadow: 0 12px 20px -12px rgba(37, 99, 235, 0.65);
+}
+
+.btn-secondary {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.btn-tertiary {
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 28px -22px rgba(15, 23, 42, 0.45);
+}
+
+.guidance-card {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 14px;
+  padding: 16px;
+  background: rgba(248, 250, 252, 0.85);
+  margin-top: 16px;
+}
+
+.guidance-card h4 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
+.guidance-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: #334155;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: rgba(16, 185, 129, 0.1);
+  border: 1px solid rgba(16, 185, 129, 0.25);
+  border-radius: 12px;
+  color: #047857;
+  font-weight: 600;
+  margin-top: 16px;
+}
+
+.status.error {
+  background: rgba(248, 113, 113, 0.1);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #b91c1c;
+}
+
+.generated-email {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.generated-email textarea {
+  min-height: 260px;
+  white-space: pre-wrap;
+}
+
+.training-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.training-table thead {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.training-table th,
+.training-table td {
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  text-align: left;
+  vertical-align: top;
+}
+
+.training-table code {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  display: block;
+  white-space: pre-wrap;
+}
+
+.attachments {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.attachment-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(37, 99, 235, 0.08);
+  color: #1e293b;
+  font-size: 0.9rem;
+}
+
+.attachment-item button {
+  border: none;
+  background: transparent;
+  color: #1d4ed8;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  #app {
+    padding: 24px 16px;
+  }
+
+  .header {
+    align-items: flex-start;
+  }
+
+  .panel {
+    padding: 20px;
+  }
+}
+
+.hidden {
+  display: none !important;
+}

--- a/src/utils/emailTemplates.js
+++ b/src/utils/emailTemplates.js
@@ -1,0 +1,148 @@
+import {
+  issueGuidance,
+  recipientGuidance,
+  escalationStyles,
+  urgencyGuidance,
+  stateRegulations,
+  federalReferences
+} from '../data/escalationRules.js';
+
+const fallback = (value, placeholder) => (value && value.trim().length ? value.trim() : placeholder);
+
+function formatList(items) {
+  return items && items.length
+    ? items.map((item, index) => `${index + 1}. ${item}`).join('\n')
+    : '';
+}
+
+export function buildEmail(formData, attachments = []) {
+  const {
+    issueType,
+    recipient,
+    location,
+    city,
+    state,
+    evidence,
+    measurements,
+    previousContact,
+    healthImpact,
+    regulations,
+    desiredOutcome,
+    escalationLevel,
+    affectedResidents,
+    propertyAge,
+    urgencyLevel,
+    senderName,
+    senderEmail,
+    senderPhone,
+    senderAddress
+  } = formData;
+
+  const issueData = issueGuidance[issueType] || null;
+  const recipientData = recipientGuidance[recipient] || null;
+  const escalation = escalationStyles[escalationLevel] || escalationStyles.professional;
+  const urgency = urgencyGuidance[urgencyLevel] || '';
+  const stateRefs = state && stateRegulations[state] ? stateRegulations[state] : [];
+
+  const subjectParts = [
+    issueData ? issueData.label : 'Indoor Environmental Concern',
+    location ? `– ${location}` : '',
+    city ? `(${city})` : ''
+  ].filter(Boolean);
+  const subject = subjectParts.join(' ');
+
+  const greeting = recipientData ? `To the ${recipientData.label},` : 'To whom it may concern,';
+
+  const introLines = [
+    `I am writing on behalf of ${fallback(senderName, 'our assessment team')} regarding ${issueData ? issueData.label.toLowerCase() : 'an indoor environmental issue'} at ${fallback(location, 'the property')} in ${[city, state].filter(Boolean).join(', ')}.`,
+    escalation.guidance
+  ].filter(Boolean);
+
+  const evidenceLines = [];
+  if (measurements) {
+    evidenceLines.push(`Measured data: ${measurements}.`);
+  }
+  if (evidence) {
+    evidenceLines.push(`Supporting evidence: ${evidence}.`);
+  }
+  if (healthImpact) {
+    evidenceLines.push(`Resident impact: ${healthImpact}.`);
+  }
+  if (affectedResidents) {
+    evidenceLines.push(`Affected residents/units: ${affectedResidents}.`);
+  }
+  if (propertyAge) {
+    evidenceLines.push(`Property details: ${propertyAge}.`);
+  }
+  if (attachments.length) {
+    evidenceLines.push(`Attachments provided: ${attachments.map((file) => file.name).join(', ')}.`);
+  }
+
+  const regulatoryLines = [];
+  if (issueData && issueData.regulations.length) {
+    regulatoryLines.push(
+      `Applicable technical guidance includes ${issueData.regulations
+        .map((reg) => reg.title)
+        .join('; ')}.`
+    );
+  }
+  if (stateRefs.length) {
+    regulatoryLines.push(
+      `Relevant ${state} provisions: ${stateRefs.map((ref) => `${ref.citation} (${ref.summary})`).join('; ')}.`
+    );
+  }
+  if (regulations) {
+    regulatoryLines.push(`Local code references provided by residents: ${regulations}.`);
+  }
+  if (recipientData) {
+    regulatoryLines.push(
+      `As noted, your obligations include ${recipientData.obligations.join(' ')} ${urgency ? `The current urgency level is ${urgency}` : ''}`.trim()
+    );
+  }
+  if (!stateRefs.length) {
+    regulatoryLines.push(
+      `Federal references to consider: ${federalReferences
+        .map((ref) => `${ref.citation} – ${ref.summary}`)
+        .join('; ')}.`
+    );
+  }
+
+  const actionLines = [];
+  if (recipientData) {
+    actionLines.push(`Requested actions: ${formatList(recipientData.requestedActions)}`);
+  }
+  if (desiredOutcome) {
+    actionLines.push(`Desired outcome from residents: ${desiredOutcome}.`);
+  }
+  if (previousContact) {
+    actionLines.push(`Previous contact history: ${previousContact}.`);
+  }
+
+  const closingLines = [
+    'Please reply with confirmation of receipt, assigned point of contact, and the proposed timeline for resolution.',
+    senderName ? `Sincerely,\n${senderName}` : 'Sincerely,\nHomeLLM Advocacy Team'
+  ];
+
+  const contactLines = [];
+  if (senderAddress) contactLines.push(senderAddress);
+  if (senderEmail) contactLines.push(senderEmail);
+  if (senderPhone) contactLines.push(senderPhone);
+
+  const bodySections = [
+    greeting,
+    '',
+    ...introLines,
+    '',
+    evidenceLines.length ? 'Key Findings:\n' + evidenceLines.map((line) => `• ${line}`).join('\n') : '',
+    regulatoryLines.length ? 'Regulatory Context:\n' + regulatoryLines.map((line) => `• ${line}`).join('\n') : '',
+    actionLines.length ? 'Requested Next Steps:\n' + actionLines.join('\n') : '',
+    '',
+    ...closingLines,
+    contactLines.length ? contactLines.join('\n') : ''
+  ].filter((section) => section && section.trim().length);
+
+  return {
+    subject,
+    body: bodySections.join('\n\n')
+  };
+}


### PR DESCRIPTION
## Summary
- implement a static HomeLLM single-page app for generating escalation emails and reviewing guidance
- add structured regulation datasets and prompt/completion training samples for accurate messaging
- document offline usage, customization points, and workflow in the README

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68e5a0b7f6cc8331b5a651454d518a66