### PR TITLE
Improve discoverability of water analysis workflow

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -73,6 +73,45 @@ body {
   border: 1px solid rgba(59, 130, 246, 0.25);
 }
 
+.panel.water-cta {
+  border: 1px dashed rgba(56, 189, 248, 0.5);
+  background: rgba(240, 249, 255, 0.9);
+  padding: 20px 24px;
+}
+
+.water-cta-body {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.water-cta h3 {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.water-cta p {
+  margin: 0;
+  color: #0369a1;
+  max-width: 520px;
+}
+
+.water-cta-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 220px;
+}
+
+.water-cta-actions small {
+  color: #0f172a;
+  opacity: 0.75;
+  font-size: 0.8rem;
+}
+
 .panel.guidance {
   border: 1px solid rgba(148, 163, 184, 0.35);
 }


### PR DESCRIPTION
## Summary
- add an inline call-to-action that makes the water analysis assistant visible when water quality is not selected
- focus the new workflow on activation and surface status messaging to guide uploads
- style the call-to-action panel to match the existing UI design

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eb077ecaec8331bd286b7b11268f0b