### PR TITLE
Enable GPT-5 PDF analysis for water reports

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -405,6 +405,38 @@ body {
   opacity: 0.7;
 }
 
+.water-config {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px solid transparent;
+}
+
+.water-config.warn {
+  background: rgba(250, 204, 21, 0.18);
+  border-color: rgba(250, 204, 21, 0.45);
+  color: #92400e;
+}
+
+.water-config.ok {
+  background: rgba(16, 185, 129, 0.18);
+  border-color: rgba(16, 185, 129, 0.45);
+  color: #065f46;
+}
+
+.water-config-endpoint {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.74rem;
+  color: inherit;
+  word-break: break-all;
+}
+
 .water-summary {
   background: white;
   border: 1px solid rgba(148, 163, 184, 0.3);

--- a/src/styles.css
+++ b/src/styles.css
@@ -73,6 +73,45 @@ body {
   border: 1px solid rgba(59, 130, 246, 0.25);
 }
 
+.panel.water-cta {
+  border: 1px dashed rgba(56, 189, 248, 0.5);
+  background: rgba(240, 249, 255, 0.9);
+  padding: 20px 24px;
+}
+
+.water-cta-body {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.water-cta h3 {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.water-cta p {
+  margin: 0;
+  color: #0369a1;
+  max-width: 520px;
+}
+
+.water-cta-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 220px;
+}
+
+.water-cta-actions small {
+  color: #0f172a;
+  opacity: 0.75;
+  font-size: 0.8rem;
+}
+
 .panel.guidance {
   border: 1px solid rgba(148, 163, 184, 0.35);
 }
@@ -278,6 +317,12 @@ body {
   color: #b91c1c;
 }
 
+.status.progress {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.35);
+  color: #1d4ed8;
+}
+
 .status-chip {
   display: inline-flex;
   align-items: center;
@@ -352,6 +397,14 @@ body {
   margin-top: 12px;
 }
 
+.water-input-hint {
+  display: block;
+  margin-top: 6px;
+  font-size: 0.75rem;
+  color: #0f172a;
+  opacity: 0.7;
+}
+
 .water-summary {
   background: white;
   border: 1px solid rgba(148, 163, 184, 0.3);
@@ -373,6 +426,25 @@ body {
 .water-result-sub {
   font-size: 0.85rem;
   color: #64748b;
+}
+
+.water-result-meta {
+  margin-top: 4px;
+  font-size: 0.75rem;
+  color: #1d4ed8;
+  font-weight: 500;
+}
+
+.water-summary-note {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  color: #1d4ed8;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  margin: 0;
+  white-space: pre-wrap;
 }
 
 .water-flags {


### PR DESCRIPTION
## Summary
- add an inline call-to-action that makes the water analysis assistant visible when water quality is not selected
- focus the new workflow on activation and surface status messaging to guide uploads
- style the call-to-action panel to match the existing UI design
- enable GPT-5-powered PDF water report analysis via configurable API, including progress feedback and richer summary metadata

## Testing
- node --check src/main.js

------
https://chatgpt.com/codex/tasks/task_e_68eb077ecaec8331bd286b7b11268f0b